### PR TITLE
Pytorch 0.4 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PyTorch implementation of papar [Counting to Explore and Generalize in Text-base
 
 ## Requirements
 * Python 3
-* [PyTorch][pytorch_install]
+* [PyTorch 0.4][pytorch_install]
 * [TextWorld][textworld_install]
 * [tensorboardX][tensorboardx_install]
 

--- a/helpers/layers.py
+++ b/helpers/layers.py
@@ -89,8 +89,8 @@ class LSTMCell(torch.nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
-        torch.nn.init.orthogonal(self.weight_hh.data)
-        torch.nn.init.xavier_uniform(self.weight_ih.data, gain=1)
+        torch.nn.init.orthogonal_(self.weight_hh.data)
+        torch.nn.init.xavier_uniform_(self.weight_ih.data, gain=1)
         if self.use_bias:
             self.bias_f.data.fill_(1.0)
             self.bias_iog.data.fill_(0.0)

--- a/helpers/layers.py
+++ b/helpers/layers.py
@@ -137,7 +137,7 @@ class LSTMCell(torch.nn.Module):
         if self.use_bias:
             pre_act = pre_act + torch.cat([self.bias_f, self.bias_iog]).unsqueeze(0)
 
-        f, i, o, g = torch.split(pre_act, split_size=self.hidden_size, dim=1)
+        f, i, o, g = torch.split(pre_act, split_size_or_sections=self.hidden_size, dim=1)
         expand_mask_ = mask_.unsqueeze(1)  # batch x None
         c_1 = torch.sigmoid(f) * c_0 + torch.sigmoid(i) * torch.tanh(g)
         c_1 = c_1 * expand_mask_ + c_0 * (1 - expand_mask_)

--- a/helpers/model.py
+++ b/helpers/model.py
@@ -67,9 +67,9 @@ class LSTM_DQN(torch.nn.Module):
         self.fake_recurrent_mask = None
 
     def init_weights(self):
-        torch.nn.init.xavier_uniform(self.action_scorer_shared.weight.data, gain=1)
-        torch.nn.init.xavier_uniform(self.action_scorer_action.weight.data, gain=1)
-        torch.nn.init.xavier_uniform(self.action_scorer_object.weight.data, gain=1)
+        torch.nn.init.xavier_uniform_(self.action_scorer_shared.weight.data, gain=1)
+        torch.nn.init.xavier_uniform_(self.action_scorer_action.weight.data, gain=1)
+        torch.nn.init.xavier_uniform_(self.action_scorer_object.weight.data, gain=1)
         self.action_scorer_shared.bias.data.fill_(0)
 
     def representation_generator(self, _input_words):

--- a/lstm_drqn_baseline/train_single_generate_agent.py
+++ b/lstm_drqn_baseline/train_single_generate_agent.py
@@ -192,8 +192,6 @@ def train(config):
                 memory_cache[b].append((curr_description_id_list[b], v_idx[b], n_idx[b], rewards_pt[b], mask_pt[b], dones[b], is_final, curr_observation_strings[b]))
 
             if current_game_step > 0 and current_game_step % config["general"]["update_per_k_game_steps"] == 0:
-                # remove dropout
-                agent.model.eval()
                 policy_loss = agent.update(replay_batch_size, history_size, update_from, discount_gamma=discount_gamma)
                 if policy_loss is None:
                     continue


### PR DESCRIPTION
Basically the changes are:

- 1. torch.cat --> torch.stack
- 2. torch.split uses new argument name split_size_or_sections
- 3. module._backend.Embedding.apply changes, so just use torch.nn.Embedding
- 4. since pytorch 0.31 it checks when updating parameters, model must be under training mode. Since we are not using dropout anyway, just removed the model.eval line during agent.update